### PR TITLE
fix: guilded request route

### DIFF
--- a/src/controllers/shield.ts
+++ b/src/controllers/shield.ts
@@ -16,7 +16,9 @@ export const getMemberCountFromGuilded = async (
     inviteId: string,
     type: string,
 ) => {
-    const url = `https://www.guilded.gg/api/content/route/metadata?route=${encodeURIComponent(`/${type}/${inviteId}`)}`;
+    const url = `https://www.guilded.gg/api/content/route/metadata?route=${encodeURIComponent(
+        `/${type}/${inviteId}`,
+    )}`;
     const guildedRequest = await fetch(url);
 
     if (!guildedRequest.ok) {

--- a/src/controllers/shield.ts
+++ b/src/controllers/shield.ts
@@ -16,9 +16,7 @@ export const getMemberCountFromGuilded = async (
     inviteId: string,
     type: string,
 ) => {
-    const url = `https://www.guilded.gg/api/content/route/metadata?route=${encodeURIComponent(
-        type === "vanity" ? `/${inviteId}` : `/${type}/${inviteId}`,
-    )}`;
+    const url = `https://www.guilded.gg/api/content/route/metadata?route=${encodeURIComponent(`/${type}/${inviteId}`)}`;
     const guildedRequest = await fetch(url);
 
     if (!guildedRequest.ok) {


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Looks like now you need to explicitly specify the type in the route
this returns not found: https://www.guilded.gg/api/content/route/metadata?route=/k1ber4Jp
this works: https://www.guilded.gg/api/content/route/metadata?route=/i/k1ber4Jp

Status
[] Code changes have been tested.

Semantic versioning classification:
[] This PR changes the library's interface (methods or parameters added)
[] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
[] This PR only includes non-code changes, like changes to documentation, README, etc.
